### PR TITLE
Add navigation buttons to Discovery page

### DIFF
--- a/Travelt/DiscoveryPageWindow.xaml
+++ b/Travelt/DiscoveryPageWindow.xaml
@@ -8,7 +8,13 @@
         Title="Discovery Feed" Height="600" Width="900">
 
     <Grid Background="#1A001F">
-        <ScrollViewer VerticalScrollBarVisibility="Auto">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <ScrollViewer Grid.Row="0" VerticalScrollBarVisibility="Auto">
             <StackPanel Margin="0,30">
 
                 <Border Width="675" 
@@ -97,14 +103,56 @@
                 </ItemsControl>
             </StackPanel>
         </ScrollViewer>
+
         <Label x:Name="noresultslabel"
-       Content="No results found :("
-       HorizontalAlignment="Center" 
-       VerticalAlignment="Center" 
-       FontSize="30" 
-       Foreground="White" 
-       FontWeight="Bold" 
-       Visibility="Collapsed">
+               Grid.Row="0"
+               Content="No results found :("
+               HorizontalAlignment="Center" 
+               VerticalAlignment="Center" 
+               FontSize="30" 
+               Foreground="White" 
+               FontWeight="Bold" 
+               Visibility="Collapsed">
         </Label>
+
+        <Grid Grid.Row="2"
+              Width="675"
+              Height="60"
+              Margin="0,0,0,15">
+
+            <Button Content="HomePage"
+                    Width="160"
+                    Height="45"
+                    Foreground="White"
+                    Background="#FF2D8C"
+                    HorizontalAlignment="Left"
+                    Cursor="Hand"
+                    Click="ToHomePage_Button">
+                
+                <Button.Resources>
+                    <Style TargetType="Border">
+                        <Setter Property="CornerRadius" Value="10"/>
+                    </Style>
+                </Button.Resources>
+            </Button>
+
+            <Button Content="Profile"
+                    Width="160"
+                    Height="45"
+                    Margin="0,0,17,0"
+                    Background="#FF2D8C"
+                    Foreground="White"
+                    HorizontalAlignment="Right"
+                    Cursor="Hand"
+                    Click="ToProfile_Button">
+                <Button.Resources>
+                    <Style TargetType="Border">
+                        <Setter Property="CornerRadius" Value="10"/>
+                    </Style>
+                </Button.Resources>
+            </Button>
+
+        </Grid>
+
     </Grid>
 </Window>

--- a/Travelt/DiscoveryPageWindow.xaml.cs
+++ b/Travelt/DiscoveryPageWindow.xaml.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Runtime;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using Travelt.Service;
+using TravelT;
 
 namespace Travelt
 {
@@ -54,6 +56,19 @@ namespace Travelt
             {
                 search_click(this, new RoutedEventArgs());
             }
+        }
+        private void ToHomePage_Button(object sender, RoutedEventArgs e)
+        {
+            HomePageWindow homePage = new HomePageWindow();
+            homePage.Show();
+            this.Close();
+        }
+
+        private void ToProfile_Button(object sender, RoutedEventArgs e)
+        {
+            ProfilePageWindow profilePage = new ProfilePageWindow();
+            profilePage.Show();
+            this.Close();
         }
     }
 }

--- a/Travelt/ProfilePageWindow.xaml
+++ b/Travelt/ProfilePageWindow.xaml
@@ -228,7 +228,7 @@
         <Grid Grid.Row="2"
               Margin="0,25,0,0">
 
-            <Button Content="To HomePage"
+            <Button Content="HomePage"
                     Width="160"
                     Height="45"
                     Foreground="White"


### PR DESCRIPTION
Added 'HomePage' and 'Profile' buttons at the bottom of the feed.

Updated Grid RowDefinitions to prevent buttons from overlapping with the ScrollViewer.

Added routing logic to open target windows and close the current view.

Also changed homepage button text from "to homepage" to "homepage"